### PR TITLE
Feature: #19 Feed 관련 Service 및 Controller 테스트 코드 작성

### DIFF
--- a/src/main/java/net/cafree/domain/feed/entity/Feed.java
+++ b/src/main/java/net/cafree/domain/feed/entity/Feed.java
@@ -8,6 +8,7 @@ import net.cafree.domain.cafe.entity.Cafe;
 import net.cafree.domain.feed.dto.response.FeedResponse;
 import net.cafree.domain.member.entity.Member;
 import net.cafree.global.BaseTime;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Feed {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,6 +45,7 @@ public class Feed {
         this.rating = rating;
         this.cafe = cafe;
         this.member = member;
+        this.baseTime = new BaseTime();
     }
 
     public void updateFeed(String contents, Double rating, Cafe cafe) {

--- a/src/main/java/net/cafree/domain/feed/entity/FeedImage.java
+++ b/src/main/java/net/cafree/domain/feed/entity/FeedImage.java
@@ -34,7 +34,7 @@ public class FeedImage {
 
     public SimpleFeedResponse toSimpleFeedResponse(){
         return SimpleFeedResponse.builder()
-                .id(id)
+                .id(feed.getId())
                 .cafeId(feed.getCafe().getId())
                 .imageUrl(imageUrl)
                 .memberId(1L)

--- a/src/main/java/net/cafree/global/BaseTime.java
+++ b/src/main/java/net/cafree/global/BaseTime.java
@@ -3,19 +3,18 @@ package net.cafree.global;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.persistence.EntityListeners;
 import java.time.LocalDateTime;
 
 @Getter
 @Embeddable
-@EntityListeners(AuditingEntityListener.class)
 public class BaseTime {
     @CreatedDate
-    LocalDateTime createdAt;
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/test/java/net/cafree/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/net/cafree/domain/feed/controller/FeedControllerTest.java
@@ -1,0 +1,335 @@
+package net.cafree.domain.feed.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.cafree.domain.cafe.entity.Cafe;
+import net.cafree.domain.cafe.entity.CafeAddress;
+import net.cafree.domain.cafe.service.CafeService;
+import net.cafree.domain.feed.dto.request.FeedAddRequest;
+import net.cafree.domain.feed.entity.Feed;
+import net.cafree.domain.feed.entity.FeedImage;
+import net.cafree.domain.feed.entity.FeedTag;
+import net.cafree.domain.feed.entity.Tag;
+import net.cafree.domain.feed.service.FeedImageService;
+import net.cafree.domain.feed.service.FeedService;
+import net.cafree.domain.feed.service.FeedTagService;
+import net.cafree.domain.feed.service.TagService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static net.cafree.util.ApiDocumentUtils.getDocumentRequest;
+import static net.cafree.util.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(FeedController.class)
+@AutoConfigureRestDocs
+public class FeedControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private FeedService feedService;
+
+    @MockBean
+    private FeedImageService feedImageService;
+
+    @MockBean
+    private TagService tagService;
+
+    @MockBean
+    private FeedTagService feedTagService;
+
+    @MockBean
+    private CafeService cafeService;
+
+    @Test
+    @DisplayName("피드를 등록한다")
+    public void feedAdd() throws Exception {
+        // given
+        Long cafeId = 1L;
+        Cafe cafe = getCafe();
+        String contents = "매장이 깔끔하고 좋네요";
+        Double rating = 4.5;
+        List<String> imageUrls = List.of(
+                "https://image.cafree.net/v1/feed/1/1.png",
+                "https://image.cafree.net/v1/feed/1/2.png",
+                "https://image.cafree.net/v1/feed/1/3.png");
+        List<Integer> imageSequences = List.of(1, 2, 3);
+        List<String> tags = List.of("안양 카페", "안양역 카페", "안양 스타벅스");
+
+        Feed feed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .cafe(cafe)
+                .member(null)
+                .build();
+        Long mockId = 1L;
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrls.get(0), feed, 1),
+                new FeedImage(imageUrls.get(1), feed, 2),
+                new FeedImage(imageUrls.get(2), feed, 3));
+        List<Tag> mockTags = List.of(
+                new Tag(tags.get(0)),
+                new Tag(tags.get(1)),
+                new Tag(tags.get(2)));
+
+        ReflectionTestUtils.setField(cafe, "id", cafeId);
+        ReflectionTestUtils.setField(feed, "id", mockId);
+
+        given((cafeService.findById(any(Long.class))))
+                .willReturn(cafe);
+        given(feedService.save(any(FeedAddRequest.class), any(Cafe.class), any()))
+                .willReturn(feed);
+        given(feedImageService.saveAll(any(FeedAddRequest.class), any(Feed.class)))
+                .willReturn(mockFeedImages);
+        given(tagService.saveAll(any(FeedAddRequest.class)))
+                .willReturn(mockTags);
+
+        // when
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .contents(contents)
+                .rating(rating)
+                .imageUrls(imageUrls)
+                .imageSequences(imageSequences)
+                .tags(tags)
+                .cafeId(cafeId)
+                .build();
+
+        ResultActions result = this.mockMvc.perform(
+                post("/api/v1/feeds")
+                        .content(objectMapper.writeValueAsString(feedAddRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)).andDo(print());
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("feed-add",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("contents").type(JsonFieldType.STRING).description("피드 내용"),
+                                fieldWithPath("rating").type(JsonFieldType.NUMBER).description("평점"),
+                                fieldWithPath("imageUrls").type(JsonFieldType.ARRAY).description("이미지 URL"),
+                                fieldWithPath("imageSequences").type(JsonFieldType.ARRAY).description("이미지 순서"),
+                                fieldWithPath("tags").type(JsonFieldType.ARRAY).description("태그"),
+                                fieldWithPath("cafeId").type(JsonFieldType.NUMBER).description("카페 ID")),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("피드 ID"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성 날짜").optional(),
+                                fieldWithPath("imageUrls").type(JsonFieldType.ARRAY).description("이미지 URL"),
+                                fieldWithPath("imageSequences").type(JsonFieldType.ARRAY).description("이미지 순서"),
+                                fieldWithPath("tags").type(JsonFieldType.ARRAY).description("태그"),
+                                fieldWithPath("cafeId").type(JsonFieldType.NUMBER).description("카페 ID"),
+                                fieldWithPath("cafeTitle").type(JsonFieldType.STRING).description("카페명"),
+                                fieldWithPath("cafePreview").type(JsonFieldType.STRING).description("카페 소개글"),
+                                fieldWithPath("rating").type(JsonFieldType.NUMBER).description("카페 평점"),
+                                fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("유저 ID"),
+                                fieldWithPath("memberNickname").type(JsonFieldType.STRING).description("유저 닉네임"))));
+    }
+
+    @Test
+    @DisplayName("특정 id의 카페를 조회한다")
+    public void feedDetails() throws Exception {
+        // given
+        Long cafeId = 1L;
+        Cafe cafe = getCafe();
+        String contents = "매장이 깔끔하고 좋네요";
+        Double rating = 4.5;
+        List<String> imageUrls = List.of(
+                "https://image.cafree.net/v1/feed/1/1.png",
+                "https://image.cafree.net/v1/feed/1/2.png",
+                "https://image.cafree.net/v1/feed/1/3.png");
+        List<Integer> imageSequences = List.of(1, 2, 3);
+        List<String> tags = List.of("안양 카페", "안양역 카페", "안양 스타벅스");
+
+        Feed feed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .cafe(cafe)
+                .member(null)
+                .build();
+        Long mockId = 1L;
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrls.get(0), feed, 1),
+                new FeedImage(imageUrls.get(1), feed, 2),
+                new FeedImage(imageUrls.get(2), feed, 3));
+        List<Tag> mockTags = List.of(
+                new Tag(tags.get(0)),
+                new Tag(tags.get(1)),
+                new Tag(tags.get(2)));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), feed),
+                new FeedTag(mockTags.get(1), feed),
+                new FeedTag(mockTags.get(2), feed));
+
+        ReflectionTestUtils.setField(cafe, "id", cafeId);
+        ReflectionTestUtils.setField(feed, "id", mockId);
+
+        given((cafeService.findById(any(Long.class))))
+                .willReturn(cafe);
+        given(feedService.findById(any(Long.class)))
+                .willReturn(feed);
+        given(feedImageService.findByFeedId(any(Long.class)))
+                .willReturn(mockFeedImages);
+        given(feedTagService.findByFeedId(any(Long.class)))
+                .willReturn(mockFeedTags);
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                get("/api/v1/feeds/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)).andDo(print());
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("feed-details",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("id").description("식별자")),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("피드 ID"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성 날짜").optional(),
+                                fieldWithPath("imageUrls").type(JsonFieldType.ARRAY).description("이미지 URL"),
+                                fieldWithPath("imageSequences").type(JsonFieldType.ARRAY).description("이미지 순서"),
+                                fieldWithPath("tags").type(JsonFieldType.ARRAY).description("태그"),
+                                fieldWithPath("cafeId").type(JsonFieldType.NUMBER).description("카페 ID"),
+                                fieldWithPath("cafeTitle").type(JsonFieldType.STRING).description("카페명"),
+                                fieldWithPath("cafePreview").type(JsonFieldType.STRING).description("카페 소개글"),
+                                fieldWithPath("rating").type(JsonFieldType.NUMBER).description("카페 평점"),
+                                fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("유저 ID"),
+                                fieldWithPath("memberNickname").type(JsonFieldType.STRING).description("유저 닉네임"))));
+    }
+
+    @Test
+    @DisplayName("모든 피드를 조회한다")
+    public void feedList() throws Exception {
+        // given
+        Long cafeId = 1L;
+        Cafe cafe = getCafe();
+        String contents = "매장이 깔끔하고 좋네요";
+        Double rating = 4.5;
+        List<String> imageUrls = List.of(
+                "https://image.cafree.net/v1/feed/1/1.png",
+                "https://image.cafree.net/v1/feed/1/2.png",
+                "https://image.cafree.net/v1/feed/1/3.png");
+        List<Integer> imageSequences = List.of(1, 2, 3);
+        List<String> tags = List.of("안양 카페", "안양역 카페", "안양 스타벅스");
+
+        Feed feed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .cafe(cafe)
+                .member(null)
+                .build();
+        Long mockId = 1L;
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrls.get(0), feed, 1),
+                new FeedImage(imageUrls.get(1), feed, 2),
+                new FeedImage(imageUrls.get(2), feed, 3));
+        List<Tag> mockTags = List.of(
+                new Tag(tags.get(0)),
+                new Tag(tags.get(1)),
+                new Tag(tags.get(2)));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), feed),
+                new FeedTag(mockTags.get(1), feed),
+                new FeedTag(mockTags.get(2), feed));
+
+        ReflectionTestUtils.setField(cafe, "id", cafeId);
+        ReflectionTestUtils.setField(feed, "id", mockId);
+
+        given(feedImageService.findFirstImage())
+                .willReturn(mockFeedImages);
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                get("/api/v1/feeds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)).andDo(print());
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("feed-list",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("피드 ID"),
+                                fieldWithPath("[].cafeId").type(JsonFieldType.NUMBER).description("카페 ID"),
+                                fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("이미지 URL"),
+                                fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("유저 ID"))));
+    }
+
+//    @Test
+//    @DisplayName("특정 id의 피드를 수정한다")
+//    public void feedModify() {
+//
+//    }
+
+//    @Test
+//    @DisplayName("특정 id의 피드를 삭제한다")
+//    public void feedRemove() {
+//
+//    }
+
+    private Cafe getCafe() {
+        String title = "스타벅스";
+        String mapUrl = "https://map.naver.com/v5/search/스타벅스%20안양일번가/place/37169041?placePath=%3Fentry=pll%26from=nx%26fromNxList=true";
+        String sido = "경기";
+        String sigungu = "안양시 만안구";
+        String dong = "안양동";
+        String doro = "장내로149번길 53";
+        String buildNo = "674-81";
+        String branch = "안양역점";
+        BigDecimal latitude = BigDecimal.valueOf(126.922145);
+        BigDecimal longitude = BigDecimal.valueOf(37.4002960);
+
+        return Cafe.builder()
+                .title(title)
+                .mapUrl(mapUrl)
+                .likeCount(0)
+                .cafeAddress(CafeAddress.builder()
+                        .sido(sido)
+                        .sigungu(sigungu)
+                        .eupmyun("")
+                        .dong(dong)
+                        .doro(doro)
+                        .buildNo(buildNo)
+                        .branch(branch)
+                        .latitude(latitude)
+                        .longitude(longitude)
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/net/cafree/domain/feed/service/FeedImageServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/FeedImageServiceTest.java
@@ -1,0 +1,222 @@
+package net.cafree.domain.feed.service;
+
+import net.cafree.domain.cafe.entity.Cafe;
+import net.cafree.domain.cafe.entity.CafeAddress;
+import net.cafree.domain.cafe.repository.CafeAddressRepository;
+import net.cafree.domain.cafe.repository.CafeRepository;
+import net.cafree.domain.feed.dto.request.FeedAddRequest;
+import net.cafree.domain.feed.entity.Feed;
+import net.cafree.domain.feed.entity.FeedImage;
+import net.cafree.domain.feed.repository.FeedImageRepository;
+import net.cafree.domain.feed.repository.FeedRepository;
+import net.cafree.domain.member.entity.Member;
+import net.cafree.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedImageServiceTest {
+
+    @InjectMocks
+    FeedImageService feedImageService;
+
+    @Mock
+    FeedImageRepository feedImageRepository;
+
+    @Mock
+    FeedRepository feedRepository;
+
+    @Mock
+    CafeRepository cafeRepository;
+
+    @Mock
+    CafeAddressRepository cafeAddressRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @AfterEach
+    public void cleanup() {
+        feedImageRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("요청 온 이미지를 모두 저장한다")
+    public void saveAll() {
+        // given
+        Feed feed = getSavedFeed();
+        String imageUrl1 = "https://image.cafree.net/v1/imageUrl1";
+        String imageUrl2 = "https://image.cafree.net/v1/imageUrl2";
+        String imageUrl3 = "https://image.cafree.net/v1/imageUrl3";
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrl1, feed, 1),
+                new FeedImage(imageUrl2, feed, 2),
+                new FeedImage(imageUrl3, feed, 3));
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .imageUrls(List.of(imageUrl1, imageUrl2, imageUrl3))
+                .imageSequences(List.of(1, 2, 3))
+                .build();
+
+        given(feedImageRepository.saveAll(any()))
+                .willReturn(mockFeedImages);
+        given(feedImageRepository.findByFeed(feed))
+                .willReturn(mockFeedImages);
+
+        // when
+        List<FeedImage> saveFeedImages = feedImageService.saveAll(feedAddRequest, feed);
+
+        // then
+        List<FeedImage> findFeedImages = feedImageService.findByFeed(feed);
+
+        assertThat(saveFeedImages.size()).isEqualTo(findFeedImages.size());
+    }
+
+    @Test
+    @DisplayName("해당 피드의 이미지 url 리스트를 리턴한다")
+    public void findByFeed() {
+        // given
+        Feed feed = getSavedFeed();
+        String imageUrl1 = "https://image.cafree.net/v1/imageUrl1";
+        String imageUrl2 = "https://image.cafree.net/v1/imageUrl2";
+        String imageUrl3 = "https://image.cafree.net/v1/imageUrl3";
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrl1, feed, 1),
+                new FeedImage(imageUrl2, feed, 2),
+                new FeedImage(imageUrl3, feed, 3));
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .imageUrls(List.of(imageUrl1, imageUrl2, imageUrl3))
+                .imageSequences(List.of(1, 2, 3))
+                .build();
+
+        given(feedImageRepository.findByFeed(feed))
+                .willReturn(mockFeedImages);
+
+        // when
+        List<FeedImage> saveFeedImages = feedImageService.saveAll(feedAddRequest, feed);
+
+        // then
+        List<FeedImage> findFeedImages = feedImageService.findByFeed(feed);
+
+        assertThat(findFeedImages.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("해당 피드의 id로 이미지 url 리스트를 가져온다")
+    public void findByFeedId() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        String imageUrl1 = "https://image.cafree.net/v1/imageUrl1";
+        String imageUrl2 = "https://image.cafree.net/v1/imageUrl2";
+        String imageUrl3 = "https://image.cafree.net/v1/imageUrl3";
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrl1, mockFeed, 1),
+                new FeedImage(imageUrl2, mockFeed, 2),
+                new FeedImage(imageUrl3, mockFeed, 3));
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .imageUrls(List.of(imageUrl1, imageUrl2, imageUrl3))
+                .imageSequences(List.of(1, 2, 3))
+                .build();
+
+        given(feedImageRepository.findByFeedId(any()))
+                .willReturn(mockFeedImages);
+
+        // when
+        List<FeedImage> saveFeedImages = feedImageService.saveAll(feedAddRequest, mockFeed);
+
+        // then
+        List<FeedImage> findFeedImages = feedImageService.findByFeedId(1L);
+
+        assertThat(findFeedImages.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("피드의 첫번째 이미지들를 반환한다")
+    public void findFirstImage() {
+        // given
+        Feed feed = getSavedFeed();
+        String imageUrl1 = "https://image.cafree.net/v1/imageUrl1";
+        String imageUrl2 = "https://image.cafree.net/v1/imageUrl2";
+        String imageUrl3 = "https://image.cafree.net/v1/imageUrl3";
+
+        List<FeedImage> mockFeedImages = List.of(
+                new FeedImage(imageUrl1, feed, 1),
+                new FeedImage(imageUrl2, feed, 2),
+                new FeedImage(imageUrl3, feed, 3));
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .imageUrls(List.of(imageUrl1, imageUrl2, imageUrl3))
+                .imageSequences(List.of(1, 2, 3))
+                .build();
+
+        given(feedImageRepository.saveAll(any()))
+                .willReturn(mockFeedImages);
+        given(feedImageRepository.findBySequence(1))
+                .willReturn(List.of(mockFeedImages.get(0)));
+
+        // when
+        feedImageService.saveAll(feedAddRequest, feed);
+
+        // then
+        List<FeedImage> findFeedImages = feedImageService.findFirstImage();
+
+        assertThat(findFeedImages.size()).isEqualTo(1);
+    }
+
+    private Feed getSavedFeed() {
+        String contents = "피드입니다.";
+        return feedRepository.save(Feed.builder()
+                .contents(contents)
+                .cafe(getSavedCafe())
+                .rating(2.5)
+                .member(getSavedMember())
+                .build());
+    }
+
+    private Cafe getSavedCafe() {
+        String title = "스타벅스";
+        String mapUrl = "https://map.naver.com/v5/search/스타벅스%20안양일번가/place/37169041?placePath=%3Fentry=pll%26from=nx%26fromNxList=true";
+        String sido = "경기";
+        String sigungu = "안양시 만안구";
+        String dong = "안양동";
+        String doro = "장내로149번길 53";
+        String build_no = "674-81";
+        String branch = "안양역점";
+        BigDecimal latitude = BigDecimal.valueOf(126.922145);
+        BigDecimal longitude = BigDecimal.valueOf(37.4002960);
+        CafeAddress cafeAddress = cafeAddressRepository.save(CafeAddress.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .dong(dong)
+                .doro(doro)
+                .buildNo(build_no)
+                .branch(branch)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build());
+
+        return cafeRepository.save(Cafe.builder()
+                .title(title)
+                .mapUrl(mapUrl)
+                .cafeAddress(cafeAddress)
+                .build());
+    }
+
+    private Member getSavedMember() {
+        String name = "홍길동";
+        return memberRepository.save(Member.builder().name(name).build());
+    }
+}

--- a/src/test/java/net/cafree/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/FeedServiceTest.java
@@ -1,0 +1,238 @@
+package net.cafree.domain.feed.service;
+
+import net.cafree.domain.cafe.entity.Cafe;
+import net.cafree.domain.cafe.entity.CafeAddress;
+import net.cafree.domain.cafe.repository.CafeAddressRepository;
+import net.cafree.domain.cafe.repository.CafeRepository;
+import net.cafree.domain.feed.dto.request.FeedAddRequest;
+import net.cafree.domain.feed.dto.request.FeedUpdateRequest;
+import net.cafree.domain.feed.entity.Feed;
+import net.cafree.domain.feed.repository.FeedRepository;
+import net.cafree.domain.member.entity.Member;
+import net.cafree.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedServiceTest {
+
+    @InjectMocks
+    FeedService feedService;
+
+    @Mock
+    FeedRepository feedRepository;
+
+    @Mock
+    CafeRepository cafeRepository;
+
+    @Mock
+    CafeAddressRepository cafeAddressRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @AfterEach
+    public void cleanup(){
+        feedRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("id를 넣으면 해당 id의 피드 반환")
+    public void findFeedById() {
+        // given
+        String contents = "test contents";
+        Double rating = 2.5;
+        Cafe mockCafe = getSavedCafe();
+        Member mockMember = getSavedMember();
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder().build();
+        Feed mockFeed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .member(mockMember)
+                .cafe(mockCafe)
+                .build();
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockFeed, "id", mockId);
+
+        given(feedRepository.save(any()))
+                .willReturn(mockFeed);
+        given(feedRepository.findById(mockId))
+                .willReturn(Optional.of(mockFeed));
+
+        // when
+        feedService.save(feedAddRequest, mockCafe, mockMember);
+
+        // then
+        Feed feed = feedService.findById(mockId);
+
+        assertThat(feed.getId()).isEqualTo(mockId);
+        assertThat(feed.getContents()).isEqualTo(contents);
+        assertThat(feed.getRating()).isEqualTo(rating);
+    }
+
+    @Test
+    @DisplayName("피드를 등록하면 등록된 피드가 반환된다")
+    public void saveFeed(){
+        // given
+        String contents = "test contents";
+        Double rating = 2.5;
+        Cafe mockCafe = getSavedCafe();
+        Member mockMember = getSavedMember();
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder().build();
+        Feed mockFeed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .member(mockMember)
+                .cafe(mockCafe)
+                .build();
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockFeed, "id", mockId);
+
+        given(feedRepository.save(any()))
+                .willReturn(mockFeed);
+
+        // when
+        Feed feed = feedService.save(feedAddRequest, mockCafe, mockMember);
+
+        // then
+        assertThat(feed.getId()).isEqualTo(mockId);
+        assertThat(feed.getContents()).isEqualTo(contents);
+        assertThat(feed.getRating()).isEqualTo(rating);
+    }
+
+    @Test
+    @DisplayName("업데이트 된 피드가 반환된다")
+    public void updateFeed(){
+        // given
+        String updatedContents = "update test contents";
+        Double updatedRating = 4.5;
+
+        String contents = "test contents";
+        Double rating = 2.5;
+        Cafe mockCafe = getSavedCafe();
+        Member mockMember = getSavedMember();
+
+        FeedUpdateRequest feedUpdateRequest = FeedUpdateRequest.builder()
+                .contents(updatedContents)
+                .cafeId(1L)
+                .rating(updatedRating)
+                .build();
+        Feed mockFeed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .member(mockMember)
+                .cafe(mockCafe)
+                .build();
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockFeed, "id", mockId);
+
+        given(feedRepository.findById(mockId))
+                .willReturn(Optional.of(mockFeed));
+
+        // when
+        Feed feed = feedService.update(mockId, feedUpdateRequest, mockCafe);
+
+        // then
+        assertThat(feed.getId()).isEqualTo(mockId);
+        assertThat(feed.getContents()).isEqualTo(updatedContents);
+        assertThat(feed.getRating()).isEqualTo(updatedRating);
+    }
+
+    @Test
+    @DisplayName("성공적으로 삭제되면 예외가 발생하지 않는다")
+    public void deleteFeedByIdSuccess(){
+        // given
+        String contents = "test contents";
+        Double rating = 2.5;
+        Cafe mockCafe = getSavedCafe();
+        Member mockMember = getSavedMember();
+
+        Feed mockFeed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .member(mockMember)
+                .cafe(mockCafe)
+                .build();
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockFeed, "id", mockId);
+
+        given(feedRepository.findById(mockId))
+                .willReturn(Optional.of(mockFeed));
+
+        // then
+        assertThatNoException()
+                .isThrownBy(() -> feedService.delete(mockId));
+    }
+
+    @Test
+    @DisplayName("성공적으로 삭제되지 않으면 예외가 발생한다")
+    public void deleteFeedByIdFail(){
+        // given
+        String contents = "test contents";
+        Double rating = 2.5;
+        Cafe mockCafe = getSavedCafe();
+        Member mockMember = getSavedMember();
+
+        Feed mockFeed = Feed.builder()
+                .contents(contents)
+                .rating(rating)
+                .member(mockMember)
+                .cafe(mockCafe)
+                .build();
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockFeed, "id", mockId);
+
+        given(feedRepository.findById(mockId))
+                .willReturn(Optional.of(mockFeed));
+
+        // then
+        assertThatThrownBy(() -> feedService.delete(2L));
+    }
+
+    private Member getSavedMember() {
+        String name = "홍길동";
+        return memberRepository.save(Member.builder().name(name).build());
+    }
+
+    private Cafe getSavedCafe() {
+        String title = "스타벅스";
+        String mapUrl = "https://map.naver.com/v5/search/스타벅스%20안양일번가/place/37169041?placePath=%3Fentry=pll%26from=nx%26fromNxList=true";
+        String sido = "경기";
+        String sigungu = "안양시 만안구";
+        String dong = "안양동";
+        String doro = "장내로149번길 53";
+        String build_no = "674-81";
+        String branch = "안양역점";
+        BigDecimal latitude = BigDecimal.valueOf(126.922145);
+        BigDecimal longitude = BigDecimal.valueOf(37.4002960);
+        CafeAddress cafeAddress = cafeAddressRepository.save(CafeAddress.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .dong(dong)
+                .doro(doro)
+                .buildNo(build_no)
+                .branch(branch)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build());
+
+        return cafeRepository.save(Cafe.builder()
+                .title(title)
+                .mapUrl(mapUrl)
+                .cafeAddress(cafeAddress)
+                .build());
+    }
+}

--- a/src/test/java/net/cafree/domain/feed/service/FeedTagServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/FeedTagServiceTest.java
@@ -1,0 +1,226 @@
+package net.cafree.domain.feed.service;
+
+import net.cafree.domain.cafe.entity.Cafe;
+import net.cafree.domain.cafe.entity.CafeAddress;
+import net.cafree.domain.cafe.repository.CafeAddressRepository;
+import net.cafree.domain.cafe.repository.CafeRepository;
+import net.cafree.domain.feed.entity.Feed;
+import net.cafree.domain.feed.entity.FeedTag;
+import net.cafree.domain.feed.entity.Tag;
+import net.cafree.domain.feed.repository.FeedRepository;
+import net.cafree.domain.feed.repository.FeedTagRepository;
+import net.cafree.domain.feed.repository.TagRepository;
+import net.cafree.domain.member.entity.Member;
+import net.cafree.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedTagServiceTest {
+
+    @InjectMocks
+    FeedTagService feedTagService;
+
+    @Mock
+    FeedTagRepository feedTagRepository;
+
+    @Mock
+    FeedRepository feedRepository;
+
+    @Mock
+    TagRepository tagRepository;
+
+    @Mock
+    CafeRepository cafeRepository;
+
+    @Mock
+    CafeAddressRepository cafeAddressRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @AfterEach
+    public void cleanup() {
+        feedTagRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("요청 온 피드와 태그들의 관계를 모두 저장한다")
+    public void saveAll() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        List<Tag> mockTags = List.of(
+                new Tag("안양 카페"),
+                new Tag("안양역 카페"),
+                new Tag("안양 스타벅스"));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), mockFeed),
+                new FeedTag(mockTags.get(1), mockFeed),
+                new FeedTag(mockTags.get(2), mockFeed));
+
+        given(feedTagRepository.saveAll(any()))
+                .willReturn(mockFeedTags);
+
+        // when
+        List<FeedTag> savedFeedTags = feedTagService.saveAll(mockFeed, mockTags);
+
+        // then
+        assertThat(savedFeedTags.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("id에 해당하는 FeedTag를 리턴한다")
+    public void findById() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        String tagName = "안양 스타벅스";
+        Tag mockTag = new Tag(tagName);
+        FeedTag mockFeedTag = new FeedTag(mockTag, mockFeed);
+        Long mockId = 1L;
+
+        ReflectionTestUtils.setField(mockFeedTag, "id", mockId);
+        given(feedTagRepository.findById(mockId))
+                .willReturn(Optional.of(mockFeedTag));
+
+        // when
+        feedTagRepository.save(mockFeedTag);
+
+        // then
+        FeedTag findFeedTag = feedTagService.findById(mockId);
+
+        assertThat(findFeedTag.getId()).isEqualTo(mockId);
+    }
+
+    @Test
+    @DisplayName("피드 id에 해당하는 FeedTag 리스트를 리턴한다")
+    public void findByFeedId() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        List<Tag> mockTags = List.of(
+                new Tag("안양 카페"),
+                new Tag("안양역 카페"),
+                new Tag("안양 스타벅스"));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), mockFeed),
+                new FeedTag(mockTags.get(1), mockFeed),
+                new FeedTag(mockTags.get(2), mockFeed));
+
+        Long mockFeedId = 1L;
+        given(feedTagRepository.findByFeedId(mockFeedId))
+                .willReturn(mockFeedTags);
+
+        // when
+        feedTagService.saveAll(mockFeed, mockTags);
+
+        // then
+        List<FeedTag> findFeedTags = feedTagService.findByFeedId(mockFeedId);
+        assertThat(findFeedTags.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("피드 id에 해당하는 FeedTag 리스트를 성공적으로 삭제하면 예외가 발생하지 않는다")
+    public void deleteAllSuccess() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        List<Tag> mockTags = List.of(
+                new Tag("안양 카페"),
+                new Tag("안양역 카페"),
+                new Tag("안양 스타벅스"));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), mockFeed),
+                new FeedTag(mockTags.get(1), mockFeed),
+                new FeedTag(mockTags.get(2), mockFeed));
+
+        Long mockFeedId = 1L;
+        given(feedTagRepository.findByFeedId(mockFeedId))
+                .willReturn(mockFeedTags);
+
+        // when
+
+        // then
+        assertThatNoException()
+                .isThrownBy(() -> feedTagService.deleteAll(mockFeedId));
+    }
+
+    @Test
+    @DisplayName("피드 id에 해당하는 FeedTag 리스트를 성공적으로 삭제하면 예외가 발생한다")
+    public void deleteAllFail() {
+        // given
+        Feed mockFeed = getSavedFeed();
+        List<Tag> mockTags = List.of(
+                new Tag("안양 카페"),
+                new Tag("안양역 카페"),
+                new Tag("안양 스타벅스"));
+        List<FeedTag> mockFeedTags = List.of(
+                new FeedTag(mockTags.get(0), mockFeed),
+                new FeedTag(mockTags.get(1), mockFeed),
+                new FeedTag(mockTags.get(2), mockFeed));
+
+        Long mockFeedId = 1L;
+        given(feedTagRepository.findByFeedId(mockFeedId))
+                .willReturn(mockFeedTags);
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> feedTagService.deleteAll(2L));
+    }
+
+    private Feed getSavedFeed() {
+        String contents = "피드입니다.";
+        return feedRepository.save(Feed.builder()
+                .contents(contents)
+                .cafe(getSavedCafe())
+                .rating(2.5)
+                .member(getSavedMember())
+                .build());
+    }
+
+    private Cafe getSavedCafe() {
+        String title = "스타벅스";
+        String mapUrl = "https://map.naver.com/v5/search/스타벅스%20안양일번가/place/37169041?placePath=%3Fentry=pll%26from=nx%26fromNxList=true";
+        String sido = "경기";
+        String sigungu = "안양시 만안구";
+        String dong = "안양동";
+        String doro = "장내로149번길 53";
+        String build_no = "674-81";
+        String branch = "안양역점";
+        BigDecimal latitude = BigDecimal.valueOf(126.922145);
+        BigDecimal longitude = BigDecimal.valueOf(37.4002960);
+        CafeAddress cafeAddress = cafeAddressRepository.save(CafeAddress.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .dong(dong)
+                .doro(doro)
+                .buildNo(build_no)
+                .branch(branch)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build());
+
+        return cafeRepository.save(Cafe.builder()
+                .title(title)
+                .mapUrl(mapUrl)
+                .cafeAddress(cafeAddress)
+                .build());
+    }
+
+    private Member getSavedMember() {
+        String name = "홍길동";
+        return memberRepository.save(Member.builder().name(name).build());
+    }
+}

--- a/src/test/java/net/cafree/domain/feed/service/TagServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/TagServiceTest.java
@@ -1,0 +1,187 @@
+package net.cafree.domain.feed.service;
+
+import net.cafree.domain.cafe.entity.Cafe;
+import net.cafree.domain.cafe.entity.CafeAddress;
+import net.cafree.domain.cafe.repository.CafeAddressRepository;
+import net.cafree.domain.cafe.repository.CafeRepository;
+import net.cafree.domain.feed.dto.request.FeedAddRequest;
+import net.cafree.domain.feed.entity.Feed;
+import net.cafree.domain.feed.entity.Tag;
+import net.cafree.domain.feed.repository.FeedRepository;
+import net.cafree.domain.feed.repository.TagRepository;
+import net.cafree.domain.member.entity.Member;
+import net.cafree.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class TagServiceTest {
+
+    @InjectMocks
+    TagService tagService;
+
+    @Mock
+    FeedRepository feedRepository;
+
+    @Mock
+    TagRepository tagRepository;
+
+    @Mock
+    CafeRepository cafeRepository;
+
+    @Mock
+    CafeAddressRepository cafeAddressRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @AfterEach
+    public void cleanup() {
+        tagRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("요청 온 피드의 태그들을 모두 저장한다")
+    public void saveAll() {
+        // given
+        Feed feed = getSavedFeed();
+        String tag1 = "스타벅스";
+        String tag2 = "안양일번가 카페";
+        String tag3 = "안양 카페";
+
+        Tag mockTag = new Tag("mock Tag");
+
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .tags(List.of(tag1, tag2, tag3))
+                .build();
+
+        given(tagRepository.save(any()))
+                .willReturn(mockTag);
+
+        // when
+        List<Tag> savedTags = tagService.saveAll(feedAddRequest);
+
+        // then
+        assertThat(savedTags.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("id에 해당하는 태그를 리턴한다")
+    public void findById() {
+        // given
+        Feed feed = getSavedFeed();
+        String tag1 = "스타벅스";
+        String tag2 = "안양일번가 카페";
+        String tag3 = "안양 카페";
+
+        Tag mockTag = new Tag(tag1);
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .tags(List.of(tag1, tag2, tag3))
+                .build();
+
+        Long mockId = 1L;
+        ReflectionTestUtils.setField(mockTag, "id", mockId);
+
+        given(tagRepository.save(any()))
+                .willReturn(mockTag);
+        given(tagRepository.findById(mockId))
+                .willReturn(Optional.of(mockTag));
+
+        // when
+        List<Tag> savedTags = tagService.saveAll(feedAddRequest);
+
+        // then
+        Tag findTag = tagService.findById(mockId);
+        assertThat(findTag.getId()).isEqualTo(mockId);
+        assertThat(findTag.getTagName()).isEqualTo(tag1);
+    }
+
+    @Test
+    @DisplayName("모든 태그를 리턴한다")
+    public void findAll() {
+        // given
+        List<Tag> mockTags = List.of(new Tag("tag1"), new Tag("tag2"), new Tag("tag3"));
+        given(tagRepository.findAll())
+                .willReturn(mockTags);
+
+        // when
+        List<Tag> tags = tagService.findAll();
+
+        // then
+        assertThat(tags.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("id 리스트에 포함돼있는 태그 리스트를 리턴한다")
+    public void findByIds() {
+        // given
+        List<Tag> mockTags = List.of(new Tag("tag1"), new Tag("tag2"), new Tag("tag3"));
+        List<Long> idList = List.of(1L, 2L);
+        given(tagRepository.findByIdIn(idList))
+                .willReturn(List.of(mockTags.get(0), mockTags.get(2)));
+
+        // when
+        List<Tag> tags = tagService.findByIds(idList);
+
+        // then
+        assertThat(tags.size()).isEqualTo(2);
+    }
+
+    private Feed getSavedFeed() {
+        String contents = "피드입니다.";
+        return feedRepository.save(Feed.builder()
+                .contents(contents)
+                .cafe(getSavedCafe())
+                .rating(2.5)
+                .member(getSavedMember())
+                .build());
+    }
+
+    private Cafe getSavedCafe() {
+        String title = "스타벅스";
+        String mapUrl = "https://map.naver.com/v5/search/스타벅스%20안양일번가/place/37169041?placePath=%3Fentry=pll%26from=nx%26fromNxList=true";
+        String sido = "경기";
+        String sigungu = "안양시 만안구";
+        String dong = "안양동";
+        String doro = "장내로149번길 53";
+        String build_no = "674-81";
+        String branch = "안양역점";
+        BigDecimal latitude = BigDecimal.valueOf(126.922145);
+        BigDecimal longitude = BigDecimal.valueOf(37.4002960);
+        CafeAddress cafeAddress = cafeAddressRepository.save(CafeAddress.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .dong(dong)
+                .doro(doro)
+                .buildNo(build_no)
+                .branch(branch)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build());
+
+        return cafeRepository.save(Cafe.builder()
+                .title(title)
+                .mapUrl(mapUrl)
+                .cafeAddress(cafeAddress)
+                .build());
+    }
+
+    private Member getSavedMember() {
+        String name = "홍길동";
+        return memberRepository.save(Member.builder().name(name).build());
+    }
+}


### PR DESCRIPTION
## 개요

> Feed 관련 Service 및 Controller 테스트 코드 작성

## 작업사항

- JPA Auditing 에러 해결
- toSimpleFeedResponse() 메서드 수정
  - `.id(id)` → `.id(feed.getId())` 
- Feed 도메인 관련 Service 테스트 코드 작성
- FeedController 테스트코드 작성
  - Tag Entity 이슈(#21)로 인한 피드 수정 및 삭제 테스트 미작성

## 변경로직

**prev**
```java

```

**changed**
```java

```

## 기타

