### PR TITLE
Feature: #21 태그 카운트 필드 추가 및 관련 로직 구현

### DIFF
--- a/src/main/java/net/cafree/domain/feed/controller/FeedController.java
+++ b/src/main/java/net/cafree/domain/feed/controller/FeedController.java
@@ -15,7 +15,6 @@ import net.cafree.domain.feed.service.FeedImageService;
 import net.cafree.domain.feed.service.FeedService;
 import net.cafree.domain.feed.service.FeedTagService;
 import net.cafree.domain.feed.service.TagService;
-import net.cafree.domain.member.entity.Member;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -55,10 +54,7 @@ public class FeedController {
 
     @PostMapping
     public ResponseEntity<FeedResponse> feedAdd(@RequestBody @Validated FeedAddRequest feedAddRequest){
-        Cafe cafe = cafeService.findById(feedAddRequest.cafeId());
-        Member member = null;
-
-        Feed feed = feedService.save(feedAddRequest, cafe, member);
+        Feed feed = feedService.save(feedAddRequest, cafeService.findById(feedAddRequest.cafeId()), null);
         List<FeedImage> feedImages = feedImageService.saveAll(feedAddRequest, feed);
         List<Tag> tags = tagService.saveAll(feedAddRequest);
 
@@ -88,9 +84,9 @@ public class FeedController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> feedRemove(@PathVariable Long id) {
-        Feed feed = feedService.findById(id);
         feedImageService.deleteAll(id);
-        feedTagService.deleteAll(id);
+        tagService.downTaggedCountOrDelete(feedTagService.deleteAll(id));
+        feedService.delete(feedService.findById(id));
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/net/cafree/domain/feed/dto/request/FeedAddRequest.java
+++ b/src/main/java/net/cafree/domain/feed/dto/request/FeedAddRequest.java
@@ -20,7 +20,7 @@ public record FeedAddRequest(String contents,
     @Builder
     public FeedAddRequest { }
 
-    public Feed toFeedEntity(Cafe cafe, Member member){
+    public Feed toFeedEntity(Cafe cafe, Member member) {
         return Feed.builder()
                 .contents(contents)
                 .rating(rating)
@@ -32,19 +32,15 @@ public record FeedAddRequest(String contents,
     public List<FeedImage> toFeedImageEntity(Feed feed) {
         List<FeedImage> feedImages = new ArrayList<>();
 
-        for(int i=0 ; i<imageSequences.size() ; i++){
+        for(int i=0 ; i<imageSequences.size() ; i++) {
             feedImages.add(new FeedImage(imageUrls.get(i), feed, imageSequences.get(i)));
         }
 
         return feedImages;
     }
 
-    public Tag toTagEntity(String tagName) {
-        return new Tag(tagName);
-    }
-
     /* 2022.11.28 - lcomment : User 기능 구현 후 수정 필요 */
-    public Member toMemberEntity(){
+    public Member toMemberEntity() {
         return null;
     }
 }

--- a/src/main/java/net/cafree/domain/feed/entity/Tag.java
+++ b/src/main/java/net/cafree/domain/feed/entity/Tag.java
@@ -17,7 +17,18 @@ public class Tag {
     @Column(length = 30, nullable = false)
     private String tagName;
 
-    public Tag(String tagName) {
+    private Integer taggedCount;
+
+    public Tag(String tagName, Integer taggedCount) {
         this.tagName = tagName;
+        this.taggedCount = taggedCount;
+    }
+
+    public void addCount(int count) {
+        this.taggedCount += count;
+    }
+
+    public void subtractCount(int count) {
+        this.taggedCount -= count;
     }
 }

--- a/src/main/java/net/cafree/domain/feed/service/FeedImageService.java
+++ b/src/main/java/net/cafree/domain/feed/service/FeedImageService.java
@@ -17,11 +17,11 @@ public class FeedImageService {
     private final FeedImageRepository feedImageRepository;
 
     @Transactional
-    public List<FeedImage> saveAll(FeedAddRequest feedAddRequest, Feed feed){
+    public List<FeedImage> saveAll(FeedAddRequest feedAddRequest, Feed feed) {
         return feedImageRepository.saveAll(feedAddRequest.toFeedImageEntity(feed));
     }
 
-    public FeedImage findById(Long id){
+    public FeedImage findById(Long id) {
         return feedImageRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
 
@@ -29,16 +29,16 @@ public class FeedImageService {
         return feedImageRepository.findBySequence(1);
     }
 
-    public List<FeedImage> findByFeed(Feed feed){
+    public List<FeedImage> findByFeed(Feed feed) {
         return feedImageRepository.findByFeed(feed);
     }
 
-    public List<FeedImage> findByFeedId(Long feedId){
+    public List<FeedImage> findByFeedId(Long feedId) {
         return feedImageRepository.findByFeedId(feedId);
     }
 
     @Transactional
-    public void deleteAll(Long id) {
-        feedImageRepository.deleteAll(findByFeedId(id));
+    public void deleteAll(Long feedId) {
+        feedImageRepository.deleteAll(findByFeedId(feedId));
     }
 }

--- a/src/main/java/net/cafree/domain/feed/service/FeedService.java
+++ b/src/main/java/net/cafree/domain/feed/service/FeedService.java
@@ -24,7 +24,7 @@ public class FeedService {
     }
 
     @Transactional
-    public Feed update(Long id, FeedUpdateRequest feedUpdateRequest, Cafe cafe){
+    public Feed update(Long id, FeedUpdateRequest feedUpdateRequest, Cafe cafe) {
         Feed feed = findById(id);
         feed.updateFeed(
                 feedUpdateRequest.contents(),
@@ -33,16 +33,16 @@ public class FeedService {
         return feed;
     }
 
-    @Transactional
-    public void delete(Long id) {
-        feedRepository.delete(findById(id));
-    }
-
     public Feed findById(Long id) {
         return feedRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
 
     public List<Feed> findAll() {
         return feedRepository.findAll();
+    }
+
+    @Transactional
+    public void delete(Feed feed) {
+        feedRepository.delete(feed);
     }
 }

--- a/src/main/java/net/cafree/domain/feed/service/FeedTagService.java
+++ b/src/main/java/net/cafree/domain/feed/service/FeedTagService.java
@@ -24,11 +24,11 @@ public class FeedTagService {
                 .collect(Collectors.toList()));
     }
 
-    public List<FeedTag> findByFeed(Feed feed){
+    public List<FeedTag> findByFeed(Feed feed) {
         return feedTagRepository.findByFeed(feed);
     }
 
-    public List<FeedTag> findByFeedId(Long feedId){
+    public List<FeedTag> findByFeedId(Long feedId) {
         return feedTagRepository.findByFeedId(feedId);
     }
 
@@ -37,7 +37,16 @@ public class FeedTagService {
     }
 
     @Transactional
-    public void deleteAll(Long id) {
-        feedTagRepository.deleteAll(findByFeedId(id));
+    public List<Tag> deleteAll(Long feedId) {
+        List<FeedTag> feedTags = findByFeedId(feedId);
+        List<Tag> tags = getTags(feedTags);
+
+        feedTagRepository.deleteAll(feedTags);
+
+        return tags;
+    }
+
+    private List<Tag> getTags(List<FeedTag> feedTags) {
+        return feedTags.stream().map(FeedTag::getTag).toList();
     }
 }

--- a/src/main/java/net/cafree/domain/feed/service/TagService.java
+++ b/src/main/java/net/cafree/domain/feed/service/TagService.java
@@ -18,32 +18,45 @@ public class TagService {
     private final TagRepository tagRepository;
 
     @Transactional
-    public List<Tag> saveAll(FeedAddRequest feedAddRequest){
+    public List<Tag> saveAll(FeedAddRequest feedAddRequest) {
         return feedAddRequest.tags().stream()
                 .map(this::getSavedTag)
                 .collect(Collectors.toList());
     }
 
     private Tag getSavedTag(String tagName) {
-        return findByTagName(tagName)
-                .orElseGet(() -> tagRepository.save(new Tag(tagName)));
+        Optional<Tag> tagByTagName = findByTagName(tagName);
 
+        if (tagByTagName.isEmpty()) {
+            return tagRepository.save(new Tag(tagName, 1));
+        }
+
+        upTaggedCount(tagByTagName.get());
+        return tagByTagName.get();
     }
 
-    public List<Tag> findByIds(List<Long> ids){
+    private void upTaggedCount(Tag tag) {
+        tag.addCount(1);
+    }
+
+    public List<Tag> findByIds(List<Long> ids) {
         return tagRepository.findByIdIn(ids);
     }
 
 
-    public Tag findById(Long id){
+    public Tag findById(Long id) {
         return tagRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
 
-    public Optional<Tag> findByTagName(String tagName){
+    public Optional<Tag> findByTagName(String tagName) {
         return tagRepository.findByTagName(tagName);
     }
 
-    public List<Tag> findAll(){
+    public List<Tag> findAll() {
         return tagRepository.findAll();
+    }
+
+    public void delete(Tag tag) {
+        tagRepository.delete(tag);
     }
 }

--- a/src/main/java/net/cafree/domain/feed/service/TagService.java
+++ b/src/main/java/net/cafree/domain/feed/service/TagService.java
@@ -39,6 +39,17 @@ public class TagService {
         tag.addCount(1);
     }
 
+    public void downTaggedCountOrDelete(List<Tag> tags) {
+        tags.stream()
+                .filter(tag -> downTaggedCount(tag) == 0)
+                .forEach(this::delete);
+    }
+
+    private Integer downTaggedCount(Tag tag) {
+        tag.subtractCount(1);
+        return tag.getTaggedCount();
+    }
+
     public List<Tag> findByIds(List<Long> ids) {
         return tagRepository.findByIdIn(ids);
     }

--- a/src/test/java/net/cafree/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/net/cafree/domain/feed/controller/FeedControllerTest.java
@@ -96,9 +96,9 @@ public class FeedControllerTest {
                 new FeedImage(imageUrls.get(1), feed, 2),
                 new FeedImage(imageUrls.get(2), feed, 3));
         List<Tag> mockTags = List.of(
-                new Tag(tags.get(0)),
-                new Tag(tags.get(1)),
-                new Tag(tags.get(2)));
+                new Tag(tags.get(0), 0),
+                new Tag(tags.get(1), 0),
+                new Tag(tags.get(2), 0));
 
         ReflectionTestUtils.setField(cafe, "id", cafeId);
         ReflectionTestUtils.setField(feed, "id", mockId);
@@ -183,9 +183,9 @@ public class FeedControllerTest {
                 new FeedImage(imageUrls.get(1), feed, 2),
                 new FeedImage(imageUrls.get(2), feed, 3));
         List<Tag> mockTags = List.of(
-                new Tag(tags.get(0)),
-                new Tag(tags.get(1)),
-                new Tag(tags.get(2)));
+                new Tag(tags.get(0), 0),
+                new Tag(tags.get(1), 0),
+                new Tag(tags.get(2), 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), feed),
                 new FeedTag(mockTags.get(1), feed),
@@ -259,9 +259,9 @@ public class FeedControllerTest {
                 new FeedImage(imageUrls.get(1), feed, 2),
                 new FeedImage(imageUrls.get(2), feed, 3));
         List<Tag> mockTags = List.of(
-                new Tag(tags.get(0)),
-                new Tag(tags.get(1)),
-                new Tag(tags.get(2)));
+                new Tag(tags.get(0), 0),
+                new Tag(tags.get(1), 0),
+                new Tag(tags.get(2), 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), feed),
                 new FeedTag(mockTags.get(1), feed),
@@ -289,9 +289,9 @@ public class FeedControllerTest {
                 new FeedImage(imageUrls2.get(1), feed2, 2),
                 new FeedImage(imageUrls2.get(2), feed2, 3));
         List<Tag> mockTags2 = List.of(
-                new Tag(tags.get(0)),
-                new Tag(tags.get(1)),
-                new Tag(tags.get(2)));
+                new Tag(tags.get(0), 0),
+                new Tag(tags.get(1), 0),
+                new Tag(tags.get(2), 0));
         List<FeedTag> mockFeedTags2 = List.of(
                 new FeedTag(mockTags.get(0), feed2),
                 new FeedTag(mockTags.get(1), feed2),

--- a/src/test/java/net/cafree/domain/feed/repository/FeedTagRepositoryTest.java
+++ b/src/test/java/net/cafree/domain/feed/repository/FeedTagRepositoryTest.java
@@ -70,7 +70,7 @@ class FeedTagRepositoryTest {
     }
 
     private Tag getSavedTag(String tag) {
-        return tagRepository.save(new Tag(tag));
+        return tagRepository.save(new Tag(tag, 0));
     }
 
     private Feed getSavedFeed() {
@@ -89,7 +89,7 @@ class FeedTagRepositoryTest {
         String sigungu = "안양시 만안구";
         String dong = "안양동";
         String doro = "장내로149번길 53";
-        String build_no = "674-81";
+        String buildNo = "674-81";
         String branch = "안양역점";
         BigDecimal latitude = BigDecimal.valueOf(126.922145);
         BigDecimal longitude = BigDecimal.valueOf(37.4002960);
@@ -98,7 +98,7 @@ class FeedTagRepositoryTest {
                 .sigungu(sigungu)
                 .dong(dong)
                 .doro(doro)
-                .buildNo(build_no)
+                .buildNo(buildNo)
                 .branch(branch)
                 .latitude(latitude)
                 .longitude(longitude)

--- a/src/test/java/net/cafree/domain/feed/repository/TagRepositoryTest.java
+++ b/src/test/java/net/cafree/domain/feed/repository/TagRepositoryTest.java
@@ -26,22 +26,22 @@ public class TagRepositoryTest {
 
     @Test
     @DisplayName("피드 태그 등록을 요청하면 새로운 피드 태그가 등록된다")
-    public void registerNewCafe(){
+    public void registerNewTag(){
         // given
         String tagName = "태그입니다.";
-        Tag tag = tagRepository.save(new Tag(tagName));
+        Tag tag = tagRepository.save(new Tag(tagName, 0));
 
         // then
         assertThat(tag.getTagName()).isEqualTo(tagName);
     }
 
     @Test
-    @DisplayName("모든 피드 태그를 반환한다")
-    public void getAllFeed() {
+    @DisplayName("모든 태그를 반환한다")
+    public void getAllTag() {
         // given
         String tagName = "태그입니다.";
-        tagRepository.save(new Tag(tagName));
-        tagRepository.save(new Tag(tagName));
+        tagRepository.save(new Tag(tagName, 0));
+        tagRepository.save(new Tag(tagName, 0));
 
         // when
         List<Tag> tags = tagRepository.findAll();

--- a/src/test/java/net/cafree/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/FeedServiceTest.java
@@ -174,7 +174,7 @@ public class FeedServiceTest {
 
         // then
         assertThatNoException()
-                .isThrownBy(() -> feedService.delete(mockId));
+                .isThrownBy(() -> feedService.delete(feedService.findById(mockId)));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class FeedServiceTest {
                 .willReturn(Optional.of(mockFeed));
 
         // then
-        assertThatThrownBy(() -> feedService.delete(2L));
+        assertThatThrownBy(() -> feedService.delete(feedService.findById(2L)));
     }
 
     private Member getSavedMember() {

--- a/src/test/java/net/cafree/domain/feed/service/FeedTagServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/FeedTagServiceTest.java
@@ -64,9 +64,9 @@ public class FeedTagServiceTest {
         // given
         Feed mockFeed = getSavedFeed();
         List<Tag> mockTags = List.of(
-                new Tag("안양 카페"),
-                new Tag("안양역 카페"),
-                new Tag("안양 스타벅스"));
+                new Tag("안양 카페", 0),
+                new Tag("안양역 카페", 0),
+                new Tag("안양 스타벅스", 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), mockFeed),
                 new FeedTag(mockTags.get(1), mockFeed),
@@ -88,7 +88,7 @@ public class FeedTagServiceTest {
         // given
         Feed mockFeed = getSavedFeed();
         String tagName = "안양 스타벅스";
-        Tag mockTag = new Tag(tagName);
+        Tag mockTag = new Tag(tagName, 0);
         FeedTag mockFeedTag = new FeedTag(mockTag, mockFeed);
         Long mockId = 1L;
 
@@ -111,9 +111,9 @@ public class FeedTagServiceTest {
         // given
         Feed mockFeed = getSavedFeed();
         List<Tag> mockTags = List.of(
-                new Tag("안양 카페"),
-                new Tag("안양역 카페"),
-                new Tag("안양 스타벅스"));
+                new Tag("안양 카페", 0),
+                new Tag("안양역 카페", 0),
+                new Tag("안양 스타벅스", 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), mockFeed),
                 new FeedTag(mockTags.get(1), mockFeed),
@@ -137,9 +137,9 @@ public class FeedTagServiceTest {
         // given
         Feed mockFeed = getSavedFeed();
         List<Tag> mockTags = List.of(
-                new Tag("안양 카페"),
-                new Tag("안양역 카페"),
-                new Tag("안양 스타벅스"));
+                new Tag("안양 카페", 0),
+                new Tag("안양역 카페", 0),
+                new Tag("안양 스타벅스", 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), mockFeed),
                 new FeedTag(mockTags.get(1), mockFeed),
@@ -162,9 +162,9 @@ public class FeedTagServiceTest {
         // given
         Feed mockFeed = getSavedFeed();
         List<Tag> mockTags = List.of(
-                new Tag("안양 카페"),
-                new Tag("안양역 카페"),
-                new Tag("안양 스타벅스"));
+                new Tag("안양 카페", 0),
+                new Tag("안양역 카페", 0),
+                new Tag("안양 스타벅스", 0));
         List<FeedTag> mockFeedTags = List.of(
                 new FeedTag(mockTags.get(0), mockFeed),
                 new FeedTag(mockTags.get(1), mockFeed),

--- a/src/test/java/net/cafree/domain/feed/service/TagServiceTest.java
+++ b/src/test/java/net/cafree/domain/feed/service/TagServiceTest.java
@@ -20,13 +20,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import javax.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TagServiceTest {
@@ -63,7 +66,7 @@ public class TagServiceTest {
         String tag2 = "안양일번가 카페";
         String tag3 = "안양 카페";
 
-        Tag mockTag = new Tag("mock Tag");
+        Tag mockTag = new Tag("mock Tag", 0);
 
         FeedAddRequest feedAddRequest = FeedAddRequest.builder()
                 .tags(List.of(tag1, tag2, tag3))
@@ -80,6 +83,28 @@ public class TagServiceTest {
     }
 
     @Test
+    @DisplayName("이미 존재하는 태그의 저장을 요청하면 카운트가 올라간다")
+    public void saveExistTag() {
+        // given
+        Feed feed = getSavedFeed();
+        String tagName = "스타벅스";
+        Tag mockTag = new Tag(tagName, 1);
+
+        FeedAddRequest feedAddRequest = FeedAddRequest.builder()
+                .tags(List.of(tagName))
+                .build();
+
+        given(tagRepository.findByTagName(tagName))
+                .willReturn(Optional.of(mockTag));
+
+        // when
+        List<Tag> savedTags = tagService.saveAll(feedAddRequest);
+
+        // then
+        assertThat(savedTags.get(0).getTaggedCount()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("id에 해당하는 태그를 리턴한다")
     public void findById() {
         // given
@@ -88,7 +113,7 @@ public class TagServiceTest {
         String tag2 = "안양일번가 카페";
         String tag3 = "안양 카페";
 
-        Tag mockTag = new Tag(tag1);
+        Tag mockTag = new Tag(tag1, 0);
         FeedAddRequest feedAddRequest = FeedAddRequest.builder()
                 .tags(List.of(tag1, tag2, tag3))
                 .build();
@@ -114,7 +139,7 @@ public class TagServiceTest {
     @DisplayName("모든 태그를 리턴한다")
     public void findAll() {
         // given
-        List<Tag> mockTags = List.of(new Tag("tag1"), new Tag("tag2"), new Tag("tag3"));
+        List<Tag> mockTags = List.of(new Tag("tag1", 0), new Tag("tag2", 0), new Tag("tag3", 0));
         given(tagRepository.findAll())
                 .willReturn(mockTags);
 
@@ -129,7 +154,7 @@ public class TagServiceTest {
     @DisplayName("id 리스트에 포함돼있는 태그 리스트를 리턴한다")
     public void findByIds() {
         // given
-        List<Tag> mockTags = List.of(new Tag("tag1"), new Tag("tag2"), new Tag("tag3"));
+        List<Tag> mockTags = List.of(new Tag("tag1", 0), new Tag("tag2", 0), new Tag("tag3", 0));
         List<Long> idList = List.of(1L, 2L);
         given(tagRepository.findByIdIn(idList))
                 .willReturn(List.of(mockTags.get(0), mockTags.get(2)));
@@ -139,6 +164,55 @@ public class TagServiceTest {
 
         // then
         assertThat(tags.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("성공적으로 태그가 삭제되면 예외가 발생하지 않는다")
+    public void deleteTagByExistTag() {
+        String tagName = "태그이름";
+        Tag tag = new Tag(tagName, 0);
+        Long mockId = 1L;
+
+        given(tagRepository.findById(mockId))
+                .willReturn(Optional.of(tag));
+
+        assertThatNoException()
+                .isThrownBy(() -> tagService.delete(tagService.findById(mockId)));
+    }
+
+    @Test
+    @DisplayName("성공적으로 태그가 삭제되지 않으면 예외가 발생한다")
+    public void deleteTagByNotExistTag() {
+        Long mockId = 1L;
+
+        assertThatThrownBy(() -> tagService.delete(tagService.findById(mockId)))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("태그 카운트를 하나씩 감소시킨다")
+    public void downTagCount() {
+        List<Tag> mockTags = List.of(new Tag("tag1", 2), new Tag("tag2", 3), new Tag("tag3", 4));
+        given(tagRepository.findAll())
+                .willReturn(mockTags);
+
+        tagService.downTaggedCountOrDelete(tagService.findAll());
+
+        assertThat(mockTags.get(0).getTaggedCount()).isEqualTo(1);
+        assertThat(mockTags.get(1).getTaggedCount()).isEqualTo(2);
+        assertThat(mockTags.get(2).getTaggedCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("태그 카운트가 0이되면 삭제시킨다")
+    public void deleteTagByZeroTaggedCount() {
+        List<Tag> mockTags = List.of(new Tag("tag1", 1), new Tag("tag2", 1));
+        given(tagRepository.findAll())
+                .willReturn(mockTags);
+
+        tagService.downTaggedCountOrDelete(tagService.findAll());
+
+        verify(tagRepository, times(2)).delete(any());
     }
 
     private Feed getSavedFeed() {


### PR DESCRIPTION
## 개요

필드에 태깅된 태그의 개수를 기록할 필요성 제기
태깅된 태그의 개수를 측정하여 0이될 시 태그 데이터를 삭제하는 방식으로 구현

## 작업사항

- 태그 카운트 필드 추가
- 태그 카운트 증감 로직 구현
- 태그 카운트 증감 로직 테스트 코드 구현

## 변경로직

**prev**
```java
@Getter
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Tag {

    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(length = 30, nullable = false)
    private String tagName;

    public Tag(String tagName) {
        this.tagName = tagName;
    }
}
```

**changed**
```java
@Getter
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Tag {

    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(length = 30, nullable = false)
    private String tagName;

    private Integer taggedCount;

    public Tag(String tagName, Integer taggedCount) {
        this.tagName = tagName;
        this.taggedCount = taggedCount;
    }

    public void addCount(int count) {
        this.taggedCount += count;
    }

    public void subtractCount(int count) {
        this.taggedCount -= count;
    }
}

```

## 기타

